### PR TITLE
Pass the current event explicitly to the handler function.

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,15 +13,15 @@
             <h1>Hello</h1>
             <h2>World</h2>
 
-            <form id="form" >
+            <form id="form">
                 <input type="text" id="entrada" placeholder="Digite seu nome"/>
-                <button onclick="cliquei()" id="botao">Enviar</button>
-            </form>        
-        
+                <button onclick="cliquei(event)">Enviar</button>
+            </form>
+
             <p>Hello, world! Eu sou a Isabelle von Randow e hoje 12/09 é considerado o dia da programadora e este é o primeiro workshop de programação que eu participo!</p>
         </div>
-    </main> 
-      
+    </main>
+
     <script src="./script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -5,7 +5,7 @@ console.log(input)
 var button = document.querySelector("button")
 console.log(button)
 
-function cliquei(){
-   event.preventDefault()
+function cliquei(ev) {
+    ev.preventDefault();
     titulo.innerText = input.value;
 }


### PR DESCRIPTION
That was referencing the global 'window.event' object, which is
fragile: https://developer.mozilla.org/en-US/docs/Web/API/Window/event

It's considered "deprecated" by Typescript's analysers, which show it with a
warning: https://github.com/microsoft/TypeScript/issues/32533

We can get the actual event by passing it explicitly to the handler
function: there's an implicit local variable in the "body" of the onclick statement: https://developer.mozilla.org/en-US/docs/Web/Guide/Events/Event_handlers.